### PR TITLE
Switch to debain as base docker image

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,17 +1,22 @@
-FROM alpine:3.1
+FROM debian:jessie
 
-RUN apk --update add collectd py-pip && \
+RUN echo "APT::Install-Recommends false;" >> /etc/apt/apt.conf.d/recommends.conf && \
+    echo "APT::AutoRemove::RecommendsImportant false;" >> /etc/apt/apt.conf.d/recommends.conf && \
+    echo "APT::AutoRemove::SuggestsImportant false;" >> /etc/apt/apt.conf.d/recommends.conf && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y collectd python-pip ca-certificates && \
     pip install envtpl
 
 COPY ./docker/collectd.conf.tpl /etc/collectd/collectd.conf.tpl
-
 COPY ./docker/run.sh /run.sh
 
 COPY . /go/src/github.com/bobrik/collectd-docker/collector
 
-RUN apk --update add go git && \
+RUN apt-get install -y golang-go git && \
     GOPATH=/go go get github.com/bobrik/collectd-docker/collector/... && \
-    apk del go git && \
+    apt-get remove -y golang-go git && \
+    apt-get autoremove -y && \
     mv /go/bin/collector /collector && \
     rm -rf /go && \
     chmod 6755 /collector


### PR DESCRIPTION
Apparently there's a bug in `musl` and therefore in alpine linux that hangs `collectd` on `read` syscall, `collector` hangs on `write`:

```
[pid 64635] write(1, "PUTVAL web309/docker_stats-ceph-backups-osd.70/gauge-cpu.system 1431101819:290020000000\n", 88 <unfinished ...>
```

The problem can be solved by firing `strace` on affected `collectd` process. Strace should attach to specific `collectd` thread that does reads from pipe to unblock `collectd`.

In my tests random 3-5 hosts out of 100 were failing in 1 hour. I haven't seen the same behavior on debian image in 5 hours.

Image size increased from 61mb to 235mb.
