### PR TITLE
allow app name to be set from an env var pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ and sent to graphite installation.
 This plugin treats containers as tasks that run as parts of apps.
 To set an application name, you should set label `collectd_docker_app`
 or env variable `COLLECTD_DOCKER_APP` to the application name.
+
+You can also set the application name by setting `COLLECTD_DOCKER_APP_ENV`
+to point to the environment variable to use for the app name.
+For example, marathon sets `MARATHON_APP_ID` and by setting
+`COLLECTD_DOCKER_APP_ENV` to `MARATHON_APP_ID` you would get the
+marathon app id.
+
 To set a task name,you should set label `collectd_docker_task`
 or env variable `COLLECTD_DOCKER_TASK` to the task name. Task name
 is optional and only useful when you can run several instances of

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ You can also set the application name by setting `COLLECTD_DOCKER_APP_ENV`
 to point to the environment variable to use for the app name.
 For example, marathon sets `MARATHON_APP_ID` and by setting
 `COLLECTD_DOCKER_APP_ENV` to `MARATHON_APP_ID` you would get the
-marathon app id.
+marathon app id. In this case it is also useful
+to set `COLLECTD_DOCKER_APP_ENV_TRIM_PREFIX` to trim prefix since
+string `<app>.<task>` is limited by 63 characters.
 
 To set a task name,you should set label `collectd_docker_task`
 or env variable `COLLECTD_DOCKER_TASK` to the task name. Task name

--- a/collector/monitor.go
+++ b/collector/monitor.go
@@ -8,10 +8,13 @@ import (
 )
 
 const appLabel = "collectd_docker_app"
+const appLocationLabel = "collectd_docker_app_label"
 const taskLabel = "collectd_docker_task"
 const taskLocationLabel = "collectd_docker_task_label"
 
 const appEnvPrefix = "COLLECTD_DOCKER_APP="
+const appEnvLocationPrefix = "COLLECTD_DOCKER_APP_ENV="
+const appEnvLocationTrimPrefix = "COLLECTD_DOCKER_APP_ENV_TRIM_PREFIX="
 const taskEnvPrefix = "COLLECTD_DOCKER_TASK="
 const taskEnvLocationPrefix = "COLLECTD_DOCKER_TASK_ENV="
 const taskEnvLocationTrimPrefix = "COLLECTD_DOCKER_TASK_ENV_TRIM_PREFIX="
@@ -91,7 +94,21 @@ func (m *Monitor) handle(ch chan<- Stats) error {
 }
 
 func extractApp(c *docker.Container) string {
-	return extractMetadata(c, appLabel, appEnvPrefix, "")
+	app := ""
+
+	location := extractMetadata(c, appLocationLabel, appEnvLocationPrefix, "")
+	if location != "" {
+		app = extractMetadata(c, location, location+"=", "")
+	} else {
+		app = extractMetadata(c, appLabel, appEnvPrefix, "")
+	}
+
+	prefix := extractEnv(c, appEnvLocationTrimPrefix)
+	if prefix != "" {
+		return strings.TrimPrefix(app, prefix)
+	}
+
+	return app
 }
 
 func extractTask(c *docker.Container) string {


### PR DESCRIPTION
We want to be able to set the app name like the task name can be set. Our usecase is setting the app name to whatever the `MARATHON_APP_ID` is set to from marathon tasks.
