### PR TITLE
Add cpu percentage metrics

### DIFF
--- a/collector/writer.go
+++ b/collector/writer.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-const collectdIntGaugeTemplate = "PUTVAL %s/docker_stats-%s.%s/gauge-%s %d:%d\n"
+const collectdFloatGaugeTemplate = "PUTVAL %s/docker_stats-%s.%s/gauge-%s %d:%f\n"
 
 // CollectdWriter is responsible for writing data
 // to wrapped writer in collectd exec plugin format
@@ -28,59 +28,60 @@ func (w CollectdWriter) Write(s Stats) error {
 	return w.writeInts(s)
 }
 
-func cpuPercentage(s Stats) uint64 {
-	cpuPercent := 0.0
-	cpuDelta := float64(s.Stats.CPUStats.CPUUsage.TotalUsage) - float64(s.Stats.PreCPUStats.CPUUsage.TotalUsage)
-	systemDelta := float64(s.Stats.CPUStats.SystemCPUUsage) - float64(s.Stats.PreCPUStats.SystemCPUUsage)
+func cpuPercentage(s Stats) float64 {
+	var (
+		cpuPercent  = 0.0
+		cpuDelta    = float64(s.Stats.CPUStats.CPUUsage.TotalUsage) - float64(s.Stats.PreCPUStats.CPUUsage.TotalUsage)
+		systemDelta = float64(s.Stats.CPUStats.SystemCPUUsage) - float64(s.Stats.PreCPUStats.SystemCPUUsage)
+	)
 	if systemDelta > 0.0 && cpuDelta > 0.0 {
 		cpuPercent = (cpuDelta / systemDelta) * float64(len(s.Stats.CPUStats.CPUUsage.PercpuUsage)) * 100.0
 	}
-
-	return uint64(cpuPercent)
+	return cpuPercent
 }
 
 func (w CollectdWriter) writeInts(s Stats) error {
-	metrics := map[string]uint64{
-		"cpu.user":       s.Stats.CPUStats.CPUUsage.UsageInUsermode,
-		"cpu.system":     s.Stats.CPUStats.CPUUsage.UsageInKernelmode,
-		"cpu.total":      s.Stats.CPUStats.CPUUsage.TotalUsage,
+	metrics := map[string]float64{
+		"cpu.user":       float64(s.Stats.CPUStats.CPUUsage.UsageInUsermode),
+		"cpu.system":     float64(s.Stats.CPUStats.CPUUsage.UsageInKernelmode),
+		"cpu.total":      float64(s.Stats.CPUStats.CPUUsage.TotalUsage),
 		"cpu.percentage": cpuPercentage(s),
 
-		"memory.limit": s.Stats.MemoryStats.Limit,
-		"memory.max":   s.Stats.MemoryStats.MaxUsage,
-		"memory.usage": s.Stats.MemoryStats.Usage,
+		"memory.limit": float64(s.Stats.MemoryStats.Limit),
+		"memory.max":   float64(s.Stats.MemoryStats.MaxUsage),
+		"memory.usage": float64(s.Stats.MemoryStats.Usage),
 
-		"memory.active_anon":   s.Stats.MemoryStats.Stats.TotalActiveAnon,
-		"memory.active_file":   s.Stats.MemoryStats.Stats.TotalActiveFile,
-		"memory.cache":         s.Stats.MemoryStats.Stats.TotalCache,
-		"memory.inactive_anon": s.Stats.MemoryStats.Stats.TotalInactiveAnon,
-		"memory.inactive_file": s.Stats.MemoryStats.Stats.TotalInactiveFile,
-		"memory.mapped_file":   s.Stats.MemoryStats.Stats.TotalMappedFile,
-		"memory.pg_fault":      s.Stats.MemoryStats.Stats.TotalPgfault,
-		"memory.pg_in":         s.Stats.MemoryStats.Stats.TotalPgpgin,
-		"memory.pg_out":        s.Stats.MemoryStats.Stats.TotalPgpgout,
-		"memory.rss":           s.Stats.MemoryStats.Stats.TotalRss,
-		"memory.rss_huge":      s.Stats.MemoryStats.Stats.TotalRssHuge,
-		"memory.unevictable":   s.Stats.MemoryStats.Stats.TotalUnevictable,
-		"memory.writeback":     s.Stats.MemoryStats.Stats.TotalWriteback,
+		"memory.active_anon":   float64(s.Stats.MemoryStats.Stats.TotalActiveAnon),
+		"memory.active_file":   float64(s.Stats.MemoryStats.Stats.TotalActiveFile),
+		"memory.cache":         float64(s.Stats.MemoryStats.Stats.TotalCache),
+		"memory.inactive_anon": float64(s.Stats.MemoryStats.Stats.TotalInactiveAnon),
+		"memory.inactive_file": float64(s.Stats.MemoryStats.Stats.TotalInactiveFile),
+		"memory.mapped_file":   float64(s.Stats.MemoryStats.Stats.TotalMappedFile),
+		"memory.pg_fault":      float64(s.Stats.MemoryStats.Stats.TotalPgfault),
+		"memory.pg_in":         float64(s.Stats.MemoryStats.Stats.TotalPgpgin),
+		"memory.pg_out":        float64(s.Stats.MemoryStats.Stats.TotalPgpgout),
+		"memory.rss":           float64(s.Stats.MemoryStats.Stats.TotalRss),
+		"memory.rss_huge":      float64(s.Stats.MemoryStats.Stats.TotalRssHuge),
+		"memory.unevictable":   float64(s.Stats.MemoryStats.Stats.TotalUnevictable),
+		"memory.writeback":     float64(s.Stats.MemoryStats.Stats.TotalWriteback),
 	}
 
 	for _, network := range s.Stats.Networks {
-		metrics["net.rx_bytes"] += network.RxBytes
-		metrics["net.rx_dropped"] += network.RxDropped
-		metrics["net.rx_errors"] += network.RxErrors
-		metrics["net.rx_packets"] += network.RxPackets
+		metrics["net.rx_bytes"] += float64(network.RxBytes)
+		metrics["net.rx_dropped"] += float64(network.RxDropped)
+		metrics["net.rx_errors"] += float64(network.RxErrors)
+		metrics["net.rx_packets"] += float64(network.RxPackets)
 
-		metrics["net.tx_bytes"] += network.TxBytes
-		metrics["net.tx_dropped"] += network.TxDropped
-		metrics["net.tx_errors"] += network.TxErrors
-		metrics["net.tx_packets"] += network.TxPackets
+		metrics["net.tx_bytes"] += float64(network.TxBytes)
+		metrics["net.tx_dropped"] += float64(network.TxDropped)
+		metrics["net.tx_errors"] += float64(network.TxErrors)
+		metrics["net.tx_packets"] += float64(network.TxPackets)
 	}
 
 	t := s.Stats.Read.Unix()
 
 	for k, v := range metrics {
-		err := w.writeInt(s, k, t, v)
+		err := w.writeFloat(s, k, t, v)
 		if err != nil {
 			return err
 		}
@@ -89,8 +90,8 @@ func (w CollectdWriter) writeInts(s Stats) error {
 	return nil
 }
 
-func (w CollectdWriter) writeInt(s Stats, k string, t int64, v uint64) error {
-	msg := fmt.Sprintf(collectdIntGaugeTemplate, w.host, s.App, s.Task, k, t, v)
+func (w CollectdWriter) writeFloat(s Stats, k string, t int64, v float64) error {
+	msg := fmt.Sprintf(collectdFloatGaugeTemplate, w.host, s.App, s.Task, k, t, v)
 	_, err := w.writer.Write([]byte(msg))
 	return err
 }

--- a/collector/writer.go
+++ b/collector/writer.go
@@ -28,11 +28,23 @@ func (w CollectdWriter) Write(s Stats) error {
 	return w.writeInts(s)
 }
 
+func cpuPercentage(s Stats) uint64 {
+	cpuPercent := 0.0
+	cpuDelta := float64(s.Stats.CPUStats.CPUUsage.TotalUsage) - float64(s.Stats.PreCPUStats.CPUUsage.TotalUsage)
+	systemDelta := float64(s.Stats.CPUStats.SystemCPUUsage) - float64(s.Stats.PreCPUStats.SystemCPUUsage)
+	if systemDelta > 0.0 && cpuDelta > 0.0 {
+		cpuPercent = (cpuDelta / systemDelta) * float64(len(s.Stats.CPUStats.CPUUsage.PercpuUsage)) * 100.0
+	}
+
+	return uint64(cpuPercent)
+}
+
 func (w CollectdWriter) writeInts(s Stats) error {
 	metrics := map[string]uint64{
-		"cpu.user":   s.Stats.CPUStats.CPUUsage.UsageInUsermode,
-		"cpu.system": s.Stats.CPUStats.CPUUsage.UsageInKernelmode,
-		"cpu.total":  s.Stats.CPUStats.CPUUsage.TotalUsage,
+		"cpu.user":       s.Stats.CPUStats.CPUUsage.UsageInUsermode,
+		"cpu.system":     s.Stats.CPUStats.CPUUsage.UsageInKernelmode,
+		"cpu.total":      s.Stats.CPUStats.CPUUsage.TotalUsage,
+		"cpu.percentage": cpuPercentage(s),
 
 		"memory.limit": s.Stats.MemoryStats.Limit,
 		"memory.max":   s.Stats.MemoryStats.MaxUsage,

--- a/collector/writer_test.go
+++ b/collector/writer_test.go
@@ -1,0 +1,118 @@
+package collector
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	"testing"
+)
+
+type CPUUsage struct {
+	PercpuUsage       []uint64 `json:"percpu_usage,omitempty" yaml:"percpu_usage,omitempty"`
+	UsageInUsermode   uint64   `json:"usage_in_usermode,omitempty" yaml:"usage_in_usermode,omitempty"`
+	TotalUsage        uint64   `json:"total_usage,omitempty" yaml:"total_usage,omitempty"`
+	UsageInKernelmode uint64   `json:"usage_in_kernelmode,omitempty" yaml:"usage_in_kernelmode,omitempty"`
+}
+
+func TestCpuPercentaget(t *testing.T) {
+	tests := []Stats{
+		Stats{
+			App:   "app-test",
+			Task:  "task-test",
+			Stats: docker.Stats{},
+		},
+		Stats{
+			App:  "app-test",
+			Task: "task-test",
+			Stats: docker.Stats{
+				CPUStats: docker.CPUStats{
+					SystemCPUUsage: uint64(31398238640000000),
+					CPUUsage: CPUUsage{
+						TotalUsage: 2594015077802,
+						PercpuUsage: []uint64{
+							323546750673,
+							324564397608,
+							317061012401,
+							316836458442,
+							281575177161,
+							275684143003,
+							43863240551,
+							44670161231,
+							43724548993,
+							47349938842,
+							43608875064,
+							44060577573,
+							23158407180,
+							18979754536,
+							95987831450,
+							119531282932,
+							101243729356,
+							106668938153,
+							3805746869,
+							5166565480,
+							2801432984,
+							2098161188,
+							3225196915,
+							4802749217,
+						},
+					},
+				},
+				PreCPUStats: docker.CPUStats{
+					SystemCPUUsage: uint64(0),
+					CPUUsage: CPUUsage{
+						TotalUsage: 0,
+					},
+				},
+			},
+		},
+		Stats{
+			App:  "app-test",
+			Task: "task-test",
+			Stats: docker.Stats{
+				CPUStats: docker.CPUStats{
+					SystemCPUUsage: 31398262460000000,
+					CPUUsage: CPUUsage{
+						TotalUsage: 2000,
+						PercpuUsage: []uint64{
+							323546750673,
+							324564397608,
+							317061012401,
+							316836458442,
+							281575177161,
+							275684143003,
+							43863240551,
+							44670161231,
+							43724548993,
+							47349938842,
+							43608875064,
+							44060577573,
+							23158407180,
+							18979754536,
+							95987831450,
+							119531282932,
+							101243729356,
+							106668938153,
+							3805746869,
+							5166565480,
+							2801432984,
+							2098161188,
+							3225196915,
+							4802749217,
+						},
+					},
+				},
+				PreCPUStats: docker.CPUStats{
+					SystemCPUUsage: 31398238640000000,
+					CPUUsage: CPUUsage{
+						TotalUsage: 2594015077802,
+					},
+				},
+			},
+		},
+	}
+
+	for c, e := range tests {
+		m := cpuPercentage(e)
+		if m < 0.0 || m > 100.0 {
+			t.Errorf("[%d] expected cpu percentage within bounds but got %f", c, m)
+		}
+	}
+}


### PR DESCRIPTION
- this PR adds cpu percentage metrics computed in a very similar fashion as docker stats
- changes the stats array to a float64 instead of uint64
