### PR TITLE
Support setting label/environment keys via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,56 @@
 # Collect docker container resource usage
 
-This is collectd plugin and docker image to collect resource usage
-from docker containers. Resource usage collected from `docker stats` API
-and sent to graphite installation.
+This is collectd plugin and docker image to collect resource usage from docker
+containers. Resource usage collected from `docker stats` API and sent to
+graphite installation. Containers can be added and removed on the fly, no need
+to restart collectd.
+
+## Configuration
 
 This plugin treats containers as tasks that run as parts of apps.
-To set an application name, you should set label `collectd_docker_app`
-or env variable `COLLECTD_DOCKER_APP` to the application name.
 
-You can also set the application name by setting `COLLECTD_DOCKER_APP_ENV`
-to point to the environment variable to use for the app name.
-For example, marathon sets `MARATHON_APP_ID` and by setting
-`COLLECTD_DOCKER_APP_ENV` to `MARATHON_APP_ID` you would get the
-marathon app id. In this case it is also useful
-to set `COLLECTD_DOCKER_APP_ENV_TRIM_PREFIX` to trim prefix since
-string `<app>.<task>` is limited by 63 characters.
+### Setting the App name of a Container
 
-To set a task name,you should set label `collectd_docker_task`
-or env variable `COLLECTD_DOCKER_TASK` to the task name. Task name
-is optional and only useful when you can run several instances of
-the same application on the same host. With task name you could
-see metrics of individual containers.
+* Set the label `collectd_docker_app` directly on the container
+* Set `collectd_docker_app_label` on the container that points to which actual
+label to use. e.g.`collectd_app_label=app_id` will use `app_id` label on the
+container
+* Set environment variable `COLLECTD_DOCKER_APP` on the container
+* Set `COLLECTD_DOCKER_APP_ENV` on the container that points to which actual
+environment variable to use. For example, marathon sets `MARATHON_APP_ID` and
+by setting `COLLECTD_DOCKER_APP_ENV` to `MARATHON_APP_ID` you would get the
+marathon app id.
 
-Alternatively, you could tell this plugin where task id is located
-by setting `collectd_docker_task_label` label pointing to
-the other label name or `COLLECTD_DOCKER_TASK_ENV` env var pointing to
-the other env variable. For example, mesos sets `MESOS_TASK_ID`
-and by setting `COLLECTD_DOCKER_TASK_ENV` to `MESOS_TASK_ID` you
-would get task id from mesos. In this case it is also useful
-to set `COLLECTD_DOCKER_TASK_ENV_TRIM_PREFIX` to trim prefix since
-string `<app>.<task>` is limited by 63 characters.
+These keys can be changed globally by setting `APP_LABEL_KEY` or `APP_ENV_KEY`
+when running the collectd container. For example, if you set `APP_ENV_KEY` to
+`MARATHON_APP_ID` on the collectd container, then this will use
+`MARATHON_APP_ID` on all running containers.
 
-Containers can be added and removed on the fly, no need to restart collectd.
+### Setting the Task name of a Container
+
+* Set the label `collectd_docker_task` directly on the container
+* Set `collectd_docker_task_label` on the container that points to which actual
+label to use. e.g.`collectd_app_label=task_id` will use `task_id` label on the
+container
+* Set environment variable `COLLECTD_DOCKER_TASK` on the container
+* Set `COLLECTD_DOCKER_TASK_ENV` on the container that points to which actual
+environment variable to use. For example, mesos sets `MESOS_TASK_ID` and by
+setting `COLLECTD_DOCKER_TASK_ENV` to `MESOS_TASK_ID` you would get the mesos
+task id.
+
+These keys can be changed globally by setting `TASK_LABEL_KEY` or `TASK_ENV_KEY`
+when running the collectd container. For example, if you set `TASK_ENV_KEY` to
+`MESOS_TASK_ID` on the collectd container, then this will use `MESOS_TASK_ID` on
+all running containers.
+
+### Limitations
+
+* If a container's app name cannot be identified, it will be not monitored. So
+if you are not seeing metrics, then it means you must check whether the app
+name is configured correctly.
+* The string `<app>.<task>` is limited by 63 characters. So it is also useful to
+set `COLLECTD_DOCKER_APP_ENV_TRIM_PREFIX` and/or
+`COLLECTD_DOCKER_TASK_ENV_TRIM_PREFIX` on the containers.
 
 ## Reported metrics
 
@@ -145,10 +164,14 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock \
 * `GRAPHITE_HOST` - host where carbon is listening for data.
 * `GRAPHITE_PORT` - port where carbon is listening for data, `2003` by default.
 * `GRAPHITE_PREFIX` - prefix for metrics in graphite, `collectd.` by default.
+* `APP_LABEL_KEY` - container label to use for app name, `collectd_docker_app` by default.
+* `APP_ENV_KEY` - container environment variable to use for app name, `COLLECTD_DOCKER_APP` by default.
+* `TASK_LABEL_KEY` - container label to use for task name, `collectd_docker_task` by default.
+* `TASK_ENV_KEY` - container environment variable to use for task name, `COLLECTD_DOCKER_TASK` by default.
 
-Note that this docker image is very minimal and libc inside does not
-support `search` directive in `/etc/resolv.conf`. You have to supply
-full hostname in `GRAPHITE_HOST` that can be resolved with nameserver.
+Note that this docker image is very minimal and libc inside does not support
+`search` directive in `/etc/resolv.conf`. You have to supply full hostname in
+`GRAPHITE_HOST` that can be resolved with nameserver.
 
 ## License
 

--- a/collector/monitor.go
+++ b/collector/monitor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
-func Getenv(env string, defaultValue string) string {
+func getenv(env string, defaultValue string) string {
   var value = os.Getenv(env)
   if len(value) > 0 {
     return value
@@ -17,15 +17,15 @@ func Getenv(env string, defaultValue string) string {
   }
 }
 
-var appLabel = Getenv("KEY_APP_LABEL", "collectd_docker_app")
+var appLabel = getenv("APP_LABEL_KEY", "collectd_docker_app")
 var appLocationLabel = "collectd_docker_app_label"
-var taskLabel = Getenv("KEY_TASK_LABEL", "collectd_docker_task")
+var taskLabel = getenv("TASK_LABEL_KEY", "collectd_docker_task")
 var taskLocationLabel = "collectd_docker_task_label"
 
-var appEnvPrefix = Getenv("KEY_APP_ENV", "COLLECTD_DOCKER_APP") + "="
+var appEnvPrefix = getenv("APP_ENV_KEY", "COLLECTD_DOCKER_APP") + "="
 var appEnvLocationPrefix = "COLLECTD_DOCKER_APP_ENV="
 var appEnvLocationTrimPrefix = "COLLECTD_DOCKER_APP_ENV_TRIM_PREFIX="
-var taskEnvPrefix = Getenv("KEY_TASK_ENV", "COLLECTD_DOCKER_TASK") + "="
+var taskEnvPrefix = getenv("TASK_ENV_KEY", "COLLECTD_DOCKER_TASK") + "="
 var taskEnvLocationPrefix = "COLLECTD_DOCKER_TASK_ENV="
 var taskEnvLocationTrimPrefix = "COLLECTD_DOCKER_TASK_ENV_TRIM_PREFIX="
 

--- a/collector/monitor.go
+++ b/collector/monitor.go
@@ -3,21 +3,31 @@ package collector
 import (
 	"errors"
 	"strings"
+	"os"
 
 	"github.com/fsouza/go-dockerclient"
 )
 
-const appLabel = "collectd_docker_app"
-const appLocationLabel = "collectd_docker_app_label"
-const taskLabel = "collectd_docker_task"
-const taskLocationLabel = "collectd_docker_task_label"
+func Getenv(env string, defaultValue string) string {
+  var value = os.Getenv(env)
+  if len(value) > 0 {
+    return value
+  } else {
+    return defaultValue
+  }
+}
 
-const appEnvPrefix = "COLLECTD_DOCKER_APP="
-const appEnvLocationPrefix = "COLLECTD_DOCKER_APP_ENV="
-const appEnvLocationTrimPrefix = "COLLECTD_DOCKER_APP_ENV_TRIM_PREFIX="
-const taskEnvPrefix = "COLLECTD_DOCKER_TASK="
-const taskEnvLocationPrefix = "COLLECTD_DOCKER_TASK_ENV="
-const taskEnvLocationTrimPrefix = "COLLECTD_DOCKER_TASK_ENV_TRIM_PREFIX="
+var appLabel = Getenv("KEY_APP_LABEL", "collectd_docker_app")
+var appLocationLabel = "collectd_docker_app_label"
+var taskLabel = Getenv("KEY_TASK_LABEL", "collectd_docker_task")
+var taskLocationLabel = "collectd_docker_task_label"
+
+var appEnvPrefix = Getenv("KEY_APP_ENV", "COLLECTD_DOCKER_APP") + "="
+var appEnvLocationPrefix = "COLLECTD_DOCKER_APP_ENV="
+var appEnvLocationTrimPrefix = "COLLECTD_DOCKER_APP_ENV_TRIM_PREFIX="
+var taskEnvPrefix = Getenv("KEY_TASK_ENV", "COLLECTD_DOCKER_TASK") + "="
+var taskEnvLocationPrefix = "COLLECTD_DOCKER_TASK_ENV="
+var taskEnvLocationTrimPrefix = "COLLECTD_DOCKER_TASK_ENV_TRIM_PREFIX="
 
 const defaultTask = "default"
 


### PR DESCRIPTION
Firstly, thanks for this awesome image. But we have one problem:
## Problem
- We use a custom env variable called `APP_NAME` to indicate name of the app
- So our target containers should be run with both `COLLECTD_DOCKER_APP_ENV=APP_NAME` as well as `APP_NAME=<our app name>`

This is very cumbersome. If all our apps are following a specific environment variable, then we should be able to set that value **globally** at this collectd-container level, rather than adding **two** environment variables for every app. I mean, if we are able to set additional variables to target containers, we may as well set the default `COLLECTD_APP_ENV` right?
## Solution
- You can now set an environment variable called `APP_ENV_KEY=<env variable that you use for apps>` when starting this `collectd` container. It will simply use this key to check all containers instead of the default `COLLECTD_DOCKER_APP`.
- Similarly, you can set `APP_LABEL_KEY`, `APP_ENV_KEY`, `TASK_LABEL_KEY`, `TASK_ENV_KEY` and those all will be used instead of the default `COLLECTD_` labels or environment variables.
- Basically configure things globally at this `collectd` container level instead of for each container
- The old way of overriding the label with `collectd_docker_app_label`, `collectd_docker_task_label`, `COLLECTD_DOCKER_APP_ENV`, `COLLECTD_DOCKER_TASK_ENV` still exists, so for some specific containers, you may set it to override the defaults as well.
