### PR TITLE
Let reefer pass on APP_ENV_KEY and TASK_ENV_KEY

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,4 +20,5 @@ fi
 useradd -g "${GROUP}" collectd-docker-collector
 
 exec reefer -t /etc/collectd/collectd.conf.tpl:/tmp/collectd.conf \
+  -e "APP_ENV_KEY" -e "TASK_ENV_KEY" \
   collectd -f -C /tmp/collectd.conf "$@" > /dev/null

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -16,7 +16,16 @@ export COLLECTD_INTERVAL=${COLLECTD_INTERVAL:-10}
 GROUP=nobody
 if [ -e /var/run/docker.sock ]; then
   GROUP=$(ls -l /var/run/docker.sock | awk '{ print $4 }')
+
+  # make sure group exists
+  if [ ! $(getent group "$GROUP") ]; then
+    # group doesn't exist, must be group id, create new group with same id
+    GROUP_ID=$GROUP
+    GROUP="docker_${GROUP_ID}"
+    groupadd -g $GROUP_ID $GROUP
+  fi
 fi
+
 useradd -g "${GROUP}" collectd-docker-collector
 
 exec reefer -t /etc/collectd/collectd.conf.tpl:/tmp/collectd.conf \


### PR DESCRIPTION
By default reefer doesn't pass on any environment variables.

We need to pass on APP_ENV_KEY and TASK_ENV_KEY for allowing global configuration of what to use for labelling.

Thanks for putting this project together!
