### PR TITLE
Let reefer pass on APP_ENV_KEY and TASK_ENV_KEY

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -19,6 +19,5 @@ if [ -e /var/run/docker.sock ]; then
 fi
 useradd -g "${GROUP}" collectd-docker-collector
 
-exec reefer -t /etc/collectd/collectd.conf.tpl:/tmp/collectd.conf \
-  -e "APP_ENV_KEY" -e "TASK_ENV_KEY" \
+exec reefer -t /etc/collectd/collectd.conf.tpl:/tmp/collectd.conf -E \
   collectd -f -C /tmp/collectd.conf "$@" > /dev/null

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,4 +20,5 @@ fi
 useradd -g "${GROUP}" collectd-docker-collector
 
 exec reefer -t /etc/collectd/collectd.conf.tpl:/tmp/collectd.conf \
+  -e "APP_ENV_KEY" -e "TASK_ENV_KEY" \
   collectd -f -C /tmp/collectd.conf "$@" > /dev/null


### PR DESCRIPTION
By default reefer doesn't pass on any environment variables.

We need to pass on APP_ENV_KEY and TASK_ENV_KEY for allowing global configuration of what to use for labelling.

Thanks for making this project!
