### PR TITLE
create group needed for /var/run/docker.sock, if needed

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -16,6 +16,14 @@ export COLLECTD_INTERVAL=${COLLECTD_INTERVAL:-10}
 GROUP=nobody
 if [ -e /var/run/docker.sock ]; then
   GROUP=$(ls -l /var/run/docker.sock | awk '{ print $4 }')
+  
+  # make sure group exists
+  if [ ! $(getent group "$GROUP") ]; then
+    # group doesn't exist, must be group id, create new group with same id
+    GROUP_ID=$GROUP
+    GROUP="docker_${GROUP_ID}"
+    groupadd -g $GROUP_ID $GROUP
+  fi
 fi
 useradd -g "${GROUP}" collectd-docker-collector
 


### PR DESCRIPTION
it's possible the group specified doesn't exist in the container.  We check to see if the group exists, if it doesn't, create a new group with same GID.
