### PR TITLE
calculate CPU percentage in the same method as docker client

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Gauges:
     * `net.tx_errors`
     * `net.tx_packets`
 
+Percent:
+
+* CPU
+    * `cpu.percent`
+
+
 ## Grafana dashboard
 
 Grafana 2 [dashboard](grafana2.json) is included.


### PR DESCRIPTION
Hi!

This may be a little weird, as I've added some state to the writer.  But, I hope there's a way to incorporate something like this...

I've been using these metrics/graphs (thanks again!), but have gotten some feedback that the CPU use in seconds is hard to reason about, and confusing when comparing against the `docker stats` command.

I was looking at how the docker client reports stats (https://github.com/docker/docker/blob/master/api/client/stats_helpers.go#L199-L212)

It uses two pieces of information that aren't currently available from these stats -- the entire system usage (CPUStats.SystemCPUUsage), and also the number of CPUs in use (len(CPUStats.CPUUsage.PercpuUsage)).

We could just start reporting those metrics (and maybe that's useful anyway), BUT, it still becomes really hard to calculate this directly in graphite/grafana.

I thought it's more clean/straightforward to calculate the percentage directly at collection time and report that (avoids the complicated calculation in graphing system, esp. where CPUs different on hosts, etc.).

This isn't SO different than the calculation already done adding up the network metrics (and i think a similar thing if we added the block io metrics at some point).

So, I'm hoping you agree the client side calculation of CPU percentage is reasonable/useful :).  Definitely open to feedback on how to integrate it more cleanly if you have it... I'm pretty much a go newbie....

thanks again.
