### PR TITLE
calculate CPU percentage in the same method as docker client

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Gauges:
     * `net.tx_errors`
     * `net.tx_packets`
 
+Percent:
+
+* CPU
+    * `cpu.percent`
+
+
 ## Grafana dashboard
 
 Grafana 2 [dashboard](grafana2.json) is included.

--- a/collector/monitor.go
+++ b/collector/monitor.go
@@ -49,6 +49,7 @@ type Monitor struct {
 	app      string
 	task     string
 	interval int
+	lastStats docker.Stats
 }
 
 // NewMonitor creates new monitor with specified docker client,
@@ -90,7 +91,10 @@ func (m *Monitor) handle(ch chan<- Stats) error {
 				App:   m.app,
 				Task:  m.task,
 				Stats: *s,
+				PrevStats: m.lastStats,
 			}
+
+			m.lastStats = *s
 
 			i++
 		}

--- a/collector/stats.go
+++ b/collector/stats.go
@@ -7,4 +7,5 @@ type Stats struct {
 	App   string
 	Task  string
 	Stats docker.Stats
+	PrevStats docker.Stats
 }

--- a/collector/writer.go
+++ b/collector/writer.go
@@ -25,7 +25,7 @@ func NewCollectdWriter(host string, writer io.Writer) CollectdWriter {
 	}
 }
 
-func (w *CollectdWriter) Write(s Stats) error {
+func (w CollectdWriter) Write(s Stats) error {
 	if err := w.writeInts(s); err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi!

I've been using these metrics/graphs (thanks again!), but have gotten some feedback that the CPU use in seconds is hard to reason about, and confusing when comparing against the docker stats command.

I was looking at how the docker client reports stats (https://github.com/docker/docker/blob/master/api/client/stats_helpers.go#L199-L212)

It uses two pieces of information that aren't currently available from these stats -- the entire system usage (CPUStats.SystemCPUUsage), and also the number of CPUs in use (len(CPUStats.CPUUsage.PercpuUsage)).

We could just start reporting those metrics (and maybe that's useful anyway), BUT, it still becomes really hard to calculate this directly in graphite/grafana.

I thought it's more clean/straightforward to calculate the percentage directly at collection time and report that (avoids the complicated calculation in graphing system, esp. where CPUs different on hosts, etc.).

So, I'm hoping you agree the client side calculation of CPU percentage is reasonable/useful :). Definitely open to feedback on how to integrate it more cleanly if you have it... I'm pretty much a go newbie....

It strikes me that it would be really cool if I could somehow do the buffering / tracking of last stats directly in the channel, without the external state -- not sure if that's possible...

Also, I should add some tests here, but I thought I'd try to get some feedback from you on this approach first....

thanks again.
